### PR TITLE
Remove RequireEncryption option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ Create a custom resource in your cloud formation template. Here's an example:
 ```yaml
   S3Bucket:
     Type: AWS::S3::Bucket
-    Properties:
-      AccessControl: Private
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
 
   SCS3BucketPolicy:
     Type: Custom::SCS3BucketPolicy
@@ -31,7 +25,6 @@ Create a custom resource in your cloud formation template. Here's an example:
         'Fn::Sub': '${AWS::Region}-cfn-cr-sc-bucket-policy-FunctionArn'
       BucketName: !Ref S3Bucket
       ExtraPrincipalArns: !Ref S3UserARNs
-      RequireEncryption: True
 ```
 
 The creation of the custom resource triggers the lambda. It creates an S3
@@ -39,7 +32,6 @@ BucketPolicy.
 * `ServiceToken` refers to the ARN of the lambda function. You can follow the pattern given; see "Install Lambda into AWS" below for the stack that exports that value.
 * The only required property is `BucketName`, a String.
 * `ExtraPrincipalArns` is one or more valid IAM policy [principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html).
-* `RequireEncryption` is a boolean value; it will default to false if left out.
 
 ## Development
 

--- a/tests/unit/test_get_params.py
+++ b/tests/unit/test_get_params.py
@@ -13,10 +13,9 @@ class TestGetParams(unittest.TestCase):
       }
     }
     result = app.get_params(event)
-    self.assertEqual(len(result), 3)
+    self.assertEqual(len(result), 2)
     self.assertEqual(result[0], bucket_name)
     self.assertEqual(result[1], [])
-    self.assertFalse(result[2])
 
 
   def test_bucketname_missing(self):
@@ -47,26 +46,3 @@ class TestGetParams(unittest.TestCase):
     }
     result = app.get_params(event)
     self.assertCountEqual([principals], result[1])
-
-
-  def test_require_encryption(self):
-    truthies = ['true', 'True', 'TRUE', True]
-    falsies = ['false', 'False', 'FALSE', '', 'foo', False, 0 ]
-    for truthy in truthies:
-      event = {
-        'ResourceProperties': {
-          'BucketName': 'some-bucket',
-          'RequireEncryption': truthy
-        }
-      }
-      result = app.get_params(event)
-      self.assertTrue(result[2])
-    for falsey in falsies:
-      event = {
-        'ResourceProperties': {
-          'BucketName': 'some-bucket',
-          'RequireEncryption': falsey
-        }
-      }
-      result = app.get_params(event)
-      self.assertFalse(result[2])

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -10,18 +10,9 @@ class TestPolicy(unittest.TestCase):
     self.principals = []
     self.maxDiff = None
 
-  def test_not_encrypted(self):
+  def test_policy_output(self):
     result = app.create_policy_document(
       bucket_name=self.bucket_name,
       principals=self.principals)
     expected = '{"Version": "2012-10-17", "Statement": [{"Sid": "ReadAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:ListBucket*", "s3:GetBucketLocation"], "Resource": "arn:aws:s3:::some-bucket-name"}, {"Sid": "WriteAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:*Object*", "s3:*MultipartUpload*"], "Resource": "arn:aws:s3:::some-bucket-name/*"}]}'
-    self.assertEqual(result, expected)
-
-
-  def test_encrypted(self):
-    result = app.create_policy_document(
-      bucket_name=self.bucket_name,
-      principals=self.principals,
-      require_encrypted=True)
-    expected = '{"Version": "2012-10-17", "Statement": [{"Sid": "ReadAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:ListBucket*", "s3:GetBucketLocation"], "Resource": "arn:aws:s3:::some-bucket-name"}, {"Sid": "WriteAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:*Object*", "s3:*MultipartUpload*"], "Resource": "arn:aws:s3:::some-bucket-name/*"}, {"Sid": "DenyIncorrectEncryptionHeader", "Effect": "Deny", "Principal": {"AWS": []}, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::some-bucket-name/*", "Condition": {"StringNotEquals": {"s3:x-amz-server-side-encryption": "AES256"}}}, {"Sid": "DenyUnEncryptedObjectUploads", "Effect": "Deny", "Principal": {"AWS": []}, "Action": "s3:PutObject", "Resource": "arn:aws:s3:::some-bucket-name/*", "Condition": {"Null": {"s3:x-amz-server-side-encryption": "true"}}}]}'
     self.assertEqual(result, expected)


### PR DESCRIPTION
Removing the `RequireEncryption` option for the custom resource which added several "Deny" statements to the policy which appear to be unnecessary for buckets that set server side encryption.
