### PR TITLE
[SC-312] Update bucket policy for cross account access

### DIFF
--- a/policy_maker/app.py
+++ b/policy_maker/app.py
@@ -100,6 +100,22 @@ def create_policy_document(bucket_name, principals):
           's3:*MultipartUpload*'
         ],
         'Resource': bucket_objects_arn
+      },
+      {
+        'Sid': 'RequireCanonicalId',
+        'Effect': 'Deny',
+        'Principal': {
+          'AWS': principals
+        },
+        'Action': [
+          's3:PutObject'
+        ],
+        'Resource': bucket_objects_arn,
+        'Condition': {
+          'StringNotEquals': {
+            's3:x-amz-acl': 'bucket-owner-full-control'
+          }
+        }
       }
     ]
   }

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -7,12 +7,105 @@ class TestPolicy(unittest.TestCase):
 
   def setUp(self):
     self.bucket_name = 'some-bucket-name'
-    self.principals = []
+    self.principals = ["arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"]
     self.maxDiff = None
 
   def test_policy_output(self):
-    result = app.create_policy_document(
+    policy = app.create_policy_document(
+      "999999999999",
       bucket_name=self.bucket_name,
       principals=self.principals)
-    expected = '{"Version": "2012-10-17", "Statement": [{"Sid": "ReadAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:ListBucket*", "s3:GetBucketLocation"], "Resource": "arn:aws:s3:::some-bucket-name"}, {"Sid": "WriteAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:*Object*", "s3:*MultipartUpload*"], "Resource": "arn:aws:s3:::some-bucket-name/*"}, {"Sid": "RequireCanonicalId", "Effect": "Deny", "Principal": {"AWS": []}, "Action": ["s3:PutObject"], "Resource": "arn:aws:s3:::some-bucket-name/*", "Condition": {"StringNotEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}}]}'
-    self.assertEqual(result, expected)
+    result = json.loads(policy)
+    exptected = {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "SynapseObjectAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
+            ]
+          },
+          "Action": [
+            "s3:*Object*",
+            "s3:*MultipartUpload*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalAccount": "325565585839"
+            }
+          },
+          "Resource": "arn:aws:s3:::some-bucket-name/*"
+        },
+        {
+          "Sid": "BucketAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
+            ]
+          },
+          "Action": [
+            "s3:ListBucket*",
+            "s3:GetBucketLocation"
+          ],
+          "Resource": "arn:aws:s3:::some-bucket-name"
+        },
+        {
+          "Sid": "ReadObjectAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
+            ]
+          },
+          "Action": [
+            "s3:GetObject",
+            "s3:GetObjectAcl",
+            "s3:AbortMultipartUpload",
+            "s3:ListMultipartUploadParts"
+          ],
+          "Resource": "arn:aws:s3:::some-bucket-name/*"
+        },
+        {
+          "Sid": "InternalPutObjectAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
+            ]
+          },
+          "Action": [
+            "s3:PutObject",
+            "s3:PutObjectAcl"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalAccount": "999999999999"
+            }
+          },
+          "Resource": "arn:aws:s3:::some-bucket-name/*"
+        },
+        {
+          "Sid": "ExternalPutObjectAccess",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
+            ]
+          },
+          "Action": [
+            "s3:PutObject",
+            "s3:PutObjectAcl"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "s3:x-amz-acl": "bucket-owner-full-control"
+            }
+          },
+          "Resource": "arn:aws:s3:::some-bucket-name/*"
+        }
+      ]
+    }
+    self.assertDictEqual(exptected, result)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -14,5 +14,5 @@ class TestPolicy(unittest.TestCase):
     result = app.create_policy_document(
       bucket_name=self.bucket_name,
       principals=self.principals)
-    expected = '{"Version": "2012-10-17", "Statement": [{"Sid": "ReadAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:ListBucket*", "s3:GetBucketLocation"], "Resource": "arn:aws:s3:::some-bucket-name"}, {"Sid": "WriteAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:*Object*", "s3:*MultipartUpload*"], "Resource": "arn:aws:s3:::some-bucket-name/*"}]}'
+    expected = '{"Version": "2012-10-17", "Statement": [{"Sid": "ReadAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:ListBucket*", "s3:GetBucketLocation"], "Resource": "arn:aws:s3:::some-bucket-name"}, {"Sid": "WriteAccess", "Effect": "Allow", "Principal": {"AWS": []}, "Action": ["s3:*Object*", "s3:*MultipartUpload*"], "Resource": "arn:aws:s3:::some-bucket-name/*"}, {"Sid": "RequireCanonicalId", "Effect": "Deny", "Principal": {"AWS": []}, "Action": ["s3:PutObject"], "Resource": "arn:aws:s3:::some-bucket-name/*", "Condition": {"StringNotEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}}]}'
     self.assertEqual(result, expected)


### PR DESCRIPTION
Update the S3 bucket policy to make synapse bucket properly work
with cross account access using the AWS console and CLI.  The policy comes
from the work done in issue IT-1295

This new policy requires users to pass the `--acl bucket-owner-full-control` flag when
uploading files to a synapse bucket.