### PR TITLE
[IT-2075] Update bucket policy generator

### DIFF
--- a/policy_maker/app.py
+++ b/policy_maker/app.py
@@ -116,43 +116,22 @@ def create_policy_document(aws_account_id, bucket_name, principals):
             "Action": [
                 "s3:GetObject",
                 "s3:GetObjectAcl",
-                "s3:AbortMultipartUpload",
                 "s3:ListMultipartUploadParts"
             ],
             "Resource": bucket_objects_arn
         },
         {
-            "Sid": "InternalPutObjectAccess",
+            "Sid": "PutObjectAccess",
             "Effect": "Allow",
             "Principal": {
                 "AWS": principals
             },
             "Action": [
                 "s3:PutObject",
-                "s3:PutObjectAcl"
+                "s3:PutObjectAcl",
+                "s3:DeleteObject",
+                "s3:*MultipartUpload*"
             ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:PrincipalAccount": aws_account_id
-                }
-            },
-            "Resource": bucket_objects_arn
-        },
-        {
-            "Sid": "ExternalPutObjectAccess",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": principals
-            },
-            "Action": [
-                "s3:PutObject",
-                "s3:PutObjectAcl"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "s3:x-amz-acl": "bucket-owner-full-control"
-                }
-            },
             "Resource": bucket_objects_arn
         }
     ]

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -63,13 +63,12 @@ class TestPolicy(unittest.TestCase):
           "Action": [
             "s3:GetObject",
             "s3:GetObjectAcl",
-            "s3:AbortMultipartUpload",
             "s3:ListMultipartUploadParts"
           ],
           "Resource": "arn:aws:s3:::some-bucket-name/*"
         },
         {
-          "Sid": "InternalPutObjectAccess",
+          "Sid": "PutObjectAccess",
           "Effect": "Allow",
           "Principal": {
             "AWS": [
@@ -78,32 +77,10 @@ class TestPolicy(unittest.TestCase):
           },
           "Action": [
             "s3:PutObject",
-            "s3:PutObjectAcl"
+            "s3:PutObjectAcl",
+            "s3:DeleteObject",
+            "s3:*MultipartUpload*"
           ],
-          "Condition": {
-            "StringEquals": {
-              "aws:PrincipalAccount": "999999999999"
-            }
-          },
-          "Resource": "arn:aws:s3:::some-bucket-name/*"
-        },
-        {
-          "Sid": "ExternalPutObjectAccess",
-          "Effect": "Allow",
-          "Principal": {
-            "AWS": [
-              "arn:aws:iam::1111111111111:user/joe.smith@sagebase.org"
-            ]
-          },
-          "Action": [
-            "s3:PutObject",
-            "s3:PutObjectAcl"
-          ],
-          "Condition": {
-            "StringEquals": {
-              "s3:x-amz-acl": "bucket-owner-full-control"
-            }
-          },
           "Resource": "arn:aws:s3:::some-bucket-name/*"
         }
       ]


### PR DESCRIPTION
We have disabled bucket ACLs[1] which requires a change to
the service catalog bucket policy.  This will update the
lambda that generates the bucket policy for service catalog
buckets.  This change is similar to the bucket policy update
for the scicomp provisioner[2]

[1] https://github.com/Sage-Bionetworks/service-catalog-library/pull/280
[2] https://github.com/Sage-Bionetworks/aws-infra/pull/351/files
