### PR TITLE
Update policy to allow removing delete markers

### DIFF
--- a/policy_maker/app.py
+++ b/policy_maker/app.py
@@ -129,7 +129,7 @@ def create_policy_document(aws_account_id, bucket_name, principals):
             "Action": [
                 "s3:PutObject",
                 "s3:PutObjectAcl",
-                "s3:DeleteObject",
+                "s3:DeleteObject*",
                 "s3:*MultipartUpload*"
             ],
             "Resource": bucket_objects_arn

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -78,7 +78,7 @@ class TestPolicy(unittest.TestCase):
           "Action": [
             "s3:PutObject",
             "s3:PutObjectAcl",
-            "s3:DeleteObject",
+            "s3:DeleteObject*",
             "s3:*MultipartUpload*"
           ],
           "Resource": "arn:aws:s3:::some-bucket-name/*"


### PR DESCRIPTION
Delete markers can get created on failed file uploads which can block users from re-uploading the same file. The user must be able to remove the delete marker before re-uploading the file. This will allow s3:DeleteObjectVersion[1] permission which will  users to remove delete markers.

[1] https://aws.amazon.com/premiumsupport/knowledge-center/s3-undelete-configuration
